### PR TITLE
Create crontab backup and uninstaller

### DIFF
--- a/install
+++ b/install
@@ -35,6 +35,9 @@ function run() {
     echo "inventory_git_url=$INVENTORY_GIT_URL" >> $CONFIG_FILE
   fi
 
+  echo Making a backup of /etc/crontab...
+  cp /etc/crontab /etc/crontab-pre-aviary
+
   echo Adding entry to /etc/crontab...
   echo "$(cat /etc/crontab | grep -v $AV_PATH)" > /etc/crontab
   echo "* * * * * root $AV_PATH directive >> /var/log/aviary-directive.log 2>&1" >> /etc/crontab

--- a/uninstall
+++ b/uninstall
@@ -3,11 +3,10 @@
 set -euo pipefail
 
 function run() {
-  VERSION=1.3.2
   INSTALL_PATH=/var/lib
   AV_PATH=$INSTALL_PATH/aviary/av
 
-  if [[ ! -e /var/lib/aviary ]]; then 
+  if [[ ! -e $INSTALL_PATH/aviary ]]; then
     echo "No existing installation at $INSTALL_PATH; exiting"
     exit 1
   fi

--- a/uninstall
+++ b/uninstall
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+function run() {
+  VERSION=1.3.2
+  INSTALL_PATH=/var/lib
+  AV_PATH=$INSTALL_PATH/aviary/av
+
+  if [[ ! -e /var/lib/aviary ]]; then 
+    echo "No existing installation at $INSTALL_PATH; exiting"
+    exit 1
+  fi
+
+  echo Uninstalling aviary from ${INSTALL_PATH}...
+  rm -rf ${INSTALL_PATH}/aviary
+  rm -f /usr/bin/av
+
+  echo Removing entries from /etc/crontab...
+  cp /etc/crontab /etc/crontab-aviary-uninstall
+  grep -v "$INSTALL_PATH/aviary" /etc/crontab > /etc/crontab.new
+  mv /etc/crontab.new /etc/crontab
+  if grep -q "$INSTALL_PATH/aviary" "/etc/crontab"; then
+    echo ERROR: Could not remove entries - please clean up /etc/crontab manually.
+  else
+    echo /etc/crontab updated - removing backup...
+    rm -f /etc/crontab-aviary-uninstall
+  fi
+
+  echo Done
+}
+
+# Wrap in function to ensure entire script is downloaded.
+run


### PR DESCRIPTION
In this PR, I have:
1. Added a line in `install` to create a backup of `/etc/crontab` before adding the entries for aviary.
2. Created an uninstaller script for easy removal if needed.

Signed-off-by: Luke Tainton <luke@tainton.uk>