### PR TITLE
WIP: Allow override install options

### DIFF
--- a/install
+++ b/install
@@ -3,12 +3,12 @@
 set -euo pipefail
 
 function run() {
-  VERSION=1.3.2
-  INSTALL_PATH=/var/lib
-  AV_PATH=$INSTALL_PATH/aviary/av
-  RELEASE_URL=https://gitlab.com/dchester/aviary.sh/-/archive/${VERSION}/aviary.sh-${VERSION}.tar.gz
+  VERSION="${VERSION:-1.3.2}"
+  INSTALL_PATH="${INSTALL_PATH:-/var/lib/aviary}"
+  AV_PATH="$INSTALL_PATH/av"
+  RELEASE_URL="${RELEASE_URL:-https://gitlab.com/dchester/aviary.sh/-/archive/${VERSION}/aviary.sh-${VERSION}.tar.gz}"
   INVENTORY_GIT_URL=${1:-""}
-  CONFIG_FILE=${INSTALL_PATH}/aviary/config
+  CONFIG_FILE="${CONFIG_FILE:-${INSTALL_PATH}/config}"
 
   # check for git dependency
   if ! /usr/bin/which git > /dev/null; then
@@ -20,24 +20,25 @@ function run() {
     echo "Installing with no inventory git url; set later in $CONFIG_FILE"
   fi
 
-  if [[ -e /var/lib/aviary ]]; then 
+  if [[ -d "$INSTALL_PATH" ]]; then
     echo "Found existing installation at $INSTALL_PATH; exiting"
     exit 1
   fi
 
   echo Installing to ${INSTALL_PATH}...
-  mkdir -p ${INSTALL_PATH}/aviary
-  curl -s $RELEASE_URL | tar --strip-components=1 -C ${INSTALL_PATH}/aviary -xz
-  ln -sf /var/lib/aviary/av /usr/bin/av
-  mkdir -p ${INSTALL_PATH}/aviary/inventory
+  mkdir -p ${INSTALL_PATH}
+  curl -s $RELEASE_URL | tar --strip-components=1 -C ${INSTALL_PATH} -xz
+  ln -sf "$AV_PATH" /usr/bin/av
+  mkdir -p ${INSTALL_PATH}/inventory
 
   if [[ ! -z "$INVENTORY_GIT_URL" ]]; then
     echo "inventory_git_url=$INVENTORY_GIT_URL" >> $CONFIG_FILE
   fi
 
   echo Adding entry to /etc/crontab...
-  echo "$(cat /etc/crontab | grep -v $AV_PATH)" > /etc/crontab
-  echo "* * * * * root $AV_PATH directive >> /var/log/aviary-directive.log 2>&1" >> /etc/crontab
+  NOW="$(date --iso-8601=minutes)"
+  sed -r -e "s|^(.*"$AV_PATH".*)|\# $NOW install disabled: \1|" /etc/crontab
+  echo "* * * * * root $AV_PATH directive >> /var/log/aviary-directive.log 2>&1  # $NOW install added" >> /etc/crontab
   echo "$(( RANDOM % 60 )) * * * * root $AV_PATH apply >> /var/log/aviary.log 2>&1" >> /etc/crontab
 
   echo Done


### PR DESCRIPTION
***(Note: Untested / speculative change)***

It's conceivable that people may want to fork and utilize their own copy
of the aviary repository.  Depending on the environment where it's
being installed, various paths and other install-time options may need
to be adjusted.  Allow for this by accepting non-default values for
key installer options.

Also, disable existing cron entries with indication of what and when.

Signed-off-by: Chris Evich <cevich@redhat.com>