### PR TITLE
Allwon Install from a GitHub url, and use cron.d instead of crontab

### DIFF
--- a/install
+++ b/install
@@ -38,10 +38,11 @@ function run() {
     echo "inventory_git_url=$INVENTORY_GIT_URL" >> $CONFIG_FILE
   fi
 
-  echo Adding entry to /etc/crontab...
-  echo "$(cat /etc/crontab | grep -v $AV_PATH)" > /etc/crontab
-  echo "* * * * * root $AV_PATH directive >> /var/log/aviary-directive.log 2>&1" >> /etc/crontab
-  echo "$(( RANDOM % 60 )) * * * * root $AV_PATH apply >> /var/log/aviary.log 2>&1" >> /etc/crontab
+  echo Adding entry to ${CRONTAB_FILE}...
+  touch ${CRONTAB_FILE}
+  echo "$(cat ${CRONTAB_FILE} | grep -v $AV_PATH)" > ${CRONTAB_FILE}
+  echo "* * * * * root $AV_PATH directive >> /var/log/aviary-directive.log 2>&1" >> ${CRONTAB_FILE}
+  echo "$(( RANDOM % 60 )) * * * * root $AV_PATH apply >> /var/log/aviary.log 2>&1" >> ${CRONTAB_FILE}
 
   echo Done
 }

--- a/install
+++ b/install
@@ -3,12 +3,15 @@
 set -euo pipefail
 
 function run() {
-  VERSION=1.3.2
+  VERSION=${VERSION:-"master"}
   INSTALL_PATH=/var/lib
   AV_PATH=$INSTALL_PATH/aviary/av
-  RELEASE_URL=https://gitlab.com/dchester/aviary.sh/-/archive/${VERSION}/aviary.sh-${VERSION}.tar.gz
-  INVENTORY_GIT_URL=${1:-""}
+  RELEASE_URL=${RELEASE_URL:-"https://github.com/team-video/aviary.sh/archive/${VERSION}.tar.gz"}
+  INVENTORY_GIT_URL=${INVENTORY_GIT_URL:-""}
   CONFIG_FILE=${INSTALL_PATH}/aviary/config
+  CRONTAB_FILE=/etc/cron.d/aviary
+
+  echo "Installing from ${RELEASE_URL}"
 
   # check for git dependency
   if ! /usr/bin/which git > /dev/null; then
@@ -20,14 +23,14 @@ function run() {
     echo "Installing with no inventory git url; set later in $CONFIG_FILE"
   fi
 
-  if [[ -e /var/lib/aviary ]]; then 
-    echo "Found existing installation at $INSTALL_PATH; exiting"
+  if [[ -e /var/lib/aviary/av ]]; then 
+    echo "Found existing installation at $AV_PATH; exiting"
     exit 1
   fi
 
   echo Installing to ${INSTALL_PATH}...
   mkdir -p ${INSTALL_PATH}/aviary
-  curl -s $RELEASE_URL | tar --strip-components=1 -C ${INSTALL_PATH}/aviary -xz
+  curl -sL $RELEASE_URL | tar --strip-components=1 -C ${INSTALL_PATH}/aviary -xz
   ln -sf /var/lib/aviary/av /usr/bin/av
   mkdir -p ${INSTALL_PATH}/aviary/inventory
 


### PR DESCRIPTION
Hi there, here are a few improvements I made for my own usage.

Install from Github
---
* Pull the code from the github repository
* Use **master** by default
* Allow configuration by ENV VARS (and use default values if not provided)
    * $VERSION could point at any commit of the repository
    * $RELEASE_URL can be changed based on the user need

Cron.d
---
Define a cron file dedicated to aviary: /etc/cron.d/aviary

That way we don't change existing crontab that may be affected by other tools.


I hope you'll find these helpful 👍 
Thank you for this great tool !