### PR TITLE
Remove set -o pipefail

### DIFF
--- a/av
+++ b/av
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -eu
 set -E
 
 export LOG_LEVEL=${LOG_LEVEL:-info}


### PR DESCRIPTION
Fixes #15

See that issue for more background. A much better alternative to this PR would be to alter the log library to stop erroring in the first place, but that may be beyond my skills.