### PR TITLE
Restore dropped commit c6b2e63

### DIFF
--- a/install
+++ b/install
@@ -2,41 +2,45 @@
 
 set -euo pipefail
 
-VERSION=1.4.0
-INSTALL_PATH=/var/lib
-AV_PATH=$INSTALL_PATH/aviary/av
-RELEASE_URL=https://github.com/frameable/aviary.sh/archive/refs/tags/v${VERSION}.tar.gz
-INVENTORY_GIT_URL=${1:-""}
-CONFIG_FILE=${INSTALL_PATH}/aviary/config
+function run() {
+  VERSION=1.4.0
+  INSTALL_PATH=/var/lib
+  AV_PATH=$INSTALL_PATH/aviary/av
+  RELEASE_URL=https://github.com/frameable/aviary.sh/archive/refs/tags/v${VERSION}.tar.gz
+  INVENTORY_GIT_URL=${1:-""}
+  CONFIG_FILE=${INSTALL_PATH}/aviary/config
 
-# check for git dependency
-if ! /usr/bin/which git > /dev/null; then
-  echo "Please install git and try again"
-  exit 1
-fi
+  # check for git dependency
+  if ! /usr/bin/which git > /dev/null; then
+    echo "Please install git and try again"
+    exit 1
+  fi
 
-if [[ -z "$INVENTORY_GIT_URL" ]]; then
-  echo "Installing with no inventory git url; set later in $CONFIG_FILE"
-fi
+  if [[ -z "$INVENTORY_GIT_URL" ]]; then
+    echo "Installing with no inventory git url; set later in $CONFIG_FILE"
+  fi
 
-if [[ -e /var/lib/aviary ]]; then 
-  echo "Found existing installation at $INSTALL_PATH; exiting"
-  exit 1
-fi
+  if [[ -e /var/lib/aviary ]]; then
+    echo "Found existing installation at $INSTALL_PATH; exiting"
+    exit 1
+  fi
 
-echo Installing to ${INSTALL_PATH}...
-mkdir -p ${INSTALL_PATH}/aviary
-curl -sL $RELEASE_URL | tar --strip-components=1 -C ${INSTALL_PATH}/aviary -xz
-ln -sf /var/lib/aviary/av /usr/bin/av
-mkdir -p ${INSTALL_PATH}/aviary/inventory
+  echo Installing to ${INSTALL_PATH}...
+  mkdir -p ${INSTALL_PATH}/aviary
+  curl -sL $RELEASE_URL | tar --strip-components=1 -C ${INSTALL_PATH}/aviary -xz
+  ln -sf /var/lib/aviary/av /usr/bin/av
+  mkdir -p ${INSTALL_PATH}/aviary/inventory
 
-if [[ ! -z "$INVENTORY_GIT_URL" ]]; then
-  echo "inventory_git_url=$INVENTORY_GIT_URL" >> $CONFIG_FILE
-fi
+  if [[ ! -z "$INVENTORY_GIT_URL" ]]; then
+    echo "inventory_git_url=$INVENTORY_GIT_URL" >> $CONFIG_FILE
+  fi
 
-echo Adding entry to /etc/crontab...
-echo "$(cat /etc/crontab | grep -v $AV_PATH)" > /etc/crontab
-echo "* * * * * root $AV_PATH directive >> /var/log/aviary-directive.log 2>&1" >> /etc/crontab
-echo "$(( RANDOM % 60 )) * * * * root $AV_PATH apply >> /var/log/aviary.log 2>&1" >> /etc/crontab
+  echo Adding entry to /etc/crontab...
+  echo "$(cat /etc/crontab | grep -v $AV_PATH)" > /etc/crontab
+  echo "* * * * * root $AV_PATH directive >> /var/log/aviary-directive.log 2>&1" >> /etc/crontab
+  echo "$(( RANDOM % 60 )) * * * * root $AV_PATH apply >> /var/log/aviary.log 2>&1" >> /etc/crontab
 
-echo Done
+  echo Done
+}
+
+run  # Wrap in function to ensure entire script is downloaded.


### PR DESCRIPTION
This introduces commit c6b2e63 into the `gh-pages` branch.

Just like @simonw in https://github.com/frameable/aviary.sh/issues/2,
I expected that visiting https://aviary.sh/install would show me the
script I was about to run.

I saw that this was discussed and allegedly fixed in
frameable/aviary.sh#3, but it appears that that pr was merged into
`origin:master/install` rather than `origin:gh-pages/install`.

Or maybe frameable/aviary.sh#3 doesn't fix the content-type header (I
don't see how it could, but I don't know much about gh-pages) and
instead just introduces a little bugfix into the install script.

Either way, c6b2e63 was lost in 60235fa. At that time,
`origin/master:install` contained changes from c6b2e63 which were not
present in `origin/gh-pages:install`.

This commit just re-introduces the intent of those changes.