### PR TITLE
Role Variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,12 +192,13 @@ There are four top-level directories: `hosts`, `roles`, `modules`, and `directiv
 The hosts directory contains a directory for each host.  In each host directory live the files:
   - `roles` - a list of roles to be fulfilled by the host
   - `modules` - a list of ad-hoc modules to be applied on the host
-  - `variables` - list of bash variable assignments local to the host
+  - `variables` - list of bash variable assignments local to the host take priority over role variables
 
 ### Roles
 
 The roles directory contains a directory for each role.  In each role directory live the files:
   - `modules` - a list of modules required to fulfill the given role
+  - `variables` - list of bash variable assignments to be supplied when assuming a role
 
 ### Modules
 
@@ -256,4 +257,3 @@ For just about three decades, bash has been standard issue on the vast majority 
 In addition to it consistently being there, it is good / good-enough at most everything we want to do while configuring a machine.  If we were using some other language half the time we'd end up shelling out anyway, so let's just stick in the shell to begin with and revel in the ease and consistency...
 
 But it's too _funky_ you say.  Well, yes, bash can have its quirks.  But we need some funk every now and then.  Let's just embrace it!
-

--- a/README.md
+++ b/README.md
@@ -192,13 +192,13 @@ There are four top-level directories: `hosts`, `roles`, `modules`, and `directiv
 The hosts directory contains a directory for each host.  In each host directory live the files:
   - `roles` - a list of roles to be fulfilled by the host
   - `modules` - a list of ad-hoc modules to be applied on the host
-  - `variables` - list of bash variable assignments local to the host take priority over role variables
+  - `variables` - list of bash variable assignments local to the host. These take priority over role variables
 
 ### Roles
 
 The roles directory contains a directory for each role.  In each role directory live the files:
   - `modules` - a list of modules required to fulfill the given role
-  - `variables` - list of bash variable assignments to be supplied when assuming a role
+  - `variables` - list of bash variable assignments to be supplied when assuming a role. Host variables can overwrite these
 
 ### Modules
 

--- a/av
+++ b/av
@@ -163,6 +163,15 @@ function host_modules {
   echo "$modules"
 }
 
+function host_variables {
+  local host=${1:-$(hostname)}
+  roles=$(grep -hs ^ $inventory_dir/hosts/$host/roles || true)
+  roles_pattern={${roles//$'\n'/,},}
+
+  variables=$(eval "{ grep -hs ^ $inventory_dir/roles/$roles_pattern/variables $inventory_dir/hosts/$host/variables || true; }" | awk '!x[$0]++')
+  echo "$variables"
+}
+
 function identify {
 
   if [[ ! -d $inventory_dir/hosts/$(hostname) ]]; then
@@ -232,7 +241,8 @@ function fetch_inventory {
 }
 
 function host_entry {
-  variables=$(grep -hs = $inventory_dir/hosts/$host/variables || true)
+  variables=$(host_variables $host)
+
   roles=$((grep -hs ^ $inventory_dir/hosts/$host/roles || true) | sed 's/^/role=/g')
   modules=$(host_modules $host | sed 's/^/module=/g')
   entries="host=${host} "$(echo $roles $modules $variables | paste -s)$'\n'
@@ -489,4 +499,3 @@ case $command in
     ;;
 
 esac
-

--- a/av
+++ b/av
@@ -96,8 +96,11 @@ function apply_module {
   local module=$1
   log_info Applying module $module
   local opts=$([[ $LOG_LEVEL == 'trace' ]] && echo '-x')
-  export $(host_variables $(hostname))
+
+  # eval to not include quote characters in values
+  eval export $(host_variables $(hostname))
   bash $opts $inventory_dir/modules/$module/apply
+
   mkdir -p $data_dir/applied_modules
   echo OK > $data_dir/applied_modules/$module
 }

--- a/av
+++ b/av
@@ -96,6 +96,7 @@ function apply_module {
   local module=$1
   log_info Applying module $module
   local opts=$([[ $LOG_LEVEL == 'trace' ]] && echo '-x')
+  export $(host_variables $(hostname))
   bash $opts $inventory_dir/modules/$module/apply
   mkdir -p $data_dir/applied_modules
   echo OK > $data_dir/applied_modules/$module


### PR DESCRIPTION
Optionally set variables for roles in in `roles/<role>/variables`

Adds a function `host_variables` that gets all of the variables that should be set for a host, preferring values set for a host explicitly to values set for a role that a host assumes. 

Adds some docs about role variables and how host variables take priority