### PR TITLE
stop cat abuse when updating roles / modules

### DIFF
--- a/av
+++ b/av
@@ -257,7 +257,8 @@ function host_remove_module {
   local host=$1
   local module=$2
   local modules_file=$inventory_dir/hosts/$host/modules
-  echo "$((grep -hs ^ $modules_file || true) | grep -v $module)" > $modules_file
+
+  echo "$(grep -v $module $modules_file)" > $modules_file
   #cp $modules_file /var/tmp/m1
   #grep -v '^$' $modules_file || true > $modules_file
 }
@@ -273,15 +274,14 @@ function host_add_module {
   fi
 
   mkdir -p $inventory_dir/hosts/$host
-  host_remove_module $host $module
-  echo $module >> $modules_file
+  echo "$(grep -v $module $modules_file)\n$module" > $modules_file
 }
 
 function host_remove_role {
   local host=$1
   local role=$2
   local roles_file=$inventory_dir/hosts/$host/roles
-  echo "$(cat $roles_file | grep -v $subcommand_arg)" > $roles_file
+  echo "$(grep -v $role $roles_file)" > $roles_file
 }
 
 function host_add_role {
@@ -295,8 +295,7 @@ function host_add_role {
   fi
 
   mkdir -p $inventory_dir/hosts/$host
-  host_remove_module $host $role
-  echo $role >> $roles_file
+  echo "$(grep -v $role $roles_file)\n$role" > $roles_file
 }
 
 function check_roles {


### PR DESCRIPTION
grep files directly instead of cat-pipe 

replace function call to remove x before adding x with similar grep logic that opens the file once

one of the functions was the wrong function and this fixes that too